### PR TITLE
*:id: Attempt to correct pub ip

### DIFF
--- a/ib_gib_umb/apps/ib_gib/config/staging.exs
+++ b/ib_gib_umb/apps/ib_gib/config/staging.exs
@@ -1,0 +1,13 @@
+use Mix.Config
+
+config :logger, level: :debug
+
+# Configure your database
+config :ib_gib, IbGib.Data.Repo,
+  adapter: Ecto.Adapters.Postgres,
+  username:  System.get_env("POSTGRES_USER") || "${POSTGRES_USER}",
+  password:  System.get_env("POSTGRES_PASSWORD") || "${POSTGRES_PASSWORD}",
+  database:  System.get_env("PG_WEBGIB_DB") || "${PG_WEBGIB_DB}",
+  hostname:  "postgres", # name in docker-compose.yml
+  port:      System.get_env("PG_PORT") || "${PG_PORT}",  # standard is 5432
+  pool_size: 20

--- a/ib_gib_umb/apps/random_gib/config/staging.exs
+++ b/ib_gib_umb/apps/random_gib/config/staging.exs
@@ -1,0 +1,3 @@
+use Mix.Config
+
+config :logger, level: :debug

--- a/ib_gib_umb/apps/web_gib/config/staging.exs
+++ b/ib_gib_umb/apps/web_gib/config/staging.exs
@@ -1,0 +1,40 @@
+use Mix.Config
+
+# For development, we disable any cache and enable
+# debugging and code reloading.
+#
+# The watchers configuration can be used to run external
+# watchers to your application. For example, we use it
+# with brunch.io to recompile .js and .css sources.
+config :web_gib, WebGib.Endpoint,
+  # http: [port: 4000],
+  https: [port: {:system, "PORT"},
+          otp_app: :web_gib,
+          keyfile: System.get_env("SSL_KEY_PATH") || "${SSL_KEY_PATH}",
+          certfile: System.get_env("SSL_CERT_PATH") || "${SSL_CERT_PATH}"],
+  debug_errors: true,
+  check_origin: false,
+  root: ".",
+  server: true
+
+# Do not include metadata nor timestamps in development logs
+# config :logger, :console, format: "[$level] $message\n"
+
+# Set a higher stacktrace during development. Avoid configuring such
+# in production as building large stacktraces may be expensive.
+# config :phoenix, :stacktrace_depth, 20
+
+# Configure your database
+config :web_gib, WebGib.Data.Repo,
+  adapter: Ecto.Adapters.Postgres,
+  username: "postgres",
+  password: "postgres",
+  database: "web_gib_dev",
+  hostname: "172.17.0.2",
+  port: 5432,
+  pool_size: 10
+
+  # Do not print debug messages in production
+  config :logger, level: :debug
+
+import_config "staging.secret.exs"

--- a/ib_gib_umb/apps/web_gib/web/plugs/ib_gib_identity.ex
+++ b/ib_gib_umb/apps/web_gib/web/plugs/ib_gib_identity.ex
@@ -61,7 +61,13 @@ defmodule WebGib.Plugs.IbGibIdentity do
     }
 
     # Thanks http://blog.danielberkompas.com/elixir/2015/06/16/rate-limiting-a-phoenix-api.html
-    ip = conn.remote_ip |> Tuple.to_list |> Enum.join(".")
+    # ip = conn.remote_ip |> Tuple.to_list |> Enum.join(".")
+    {_, ip} =
+      conn.req_headers
+      |> Enum.filter(fn({header_key, header_value}) ->
+           header_key == "x-real-ip"
+         end)
+      |> Enum.at(0)
     pub_data = %{
       "type" => "session",
       "ip" => ip

--- a/ib_gib_umb/nginx/default.conf
+++ b/ib_gib_umb/nginx/default.conf
@@ -17,6 +17,9 @@ server {
 server {
     client_max_body_size 9M;
 
+    proxy_set_header        X-Real-IP       $remote_addr;
+    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+    
     listen        443;
     server_name www.ibgib.com;
     ssl on;

--- a/ib_gib_umb/rel/config.exs
+++ b/ib_gib_umb/rel/config.exs
@@ -19,6 +19,12 @@ environment :dev do
   set cookie: :":ALx<_H|[~3W,LmaHKd/BE0^vn!GoW.ZaP6&mGo0tz3&BzaeQp;s<N+:_n_q6*bd"
 end
 
+environment :staging do
+  set dev_mode: false
+  set include_erts: true
+  set cookie: :":ALx<_H|[~3W,LmaHKd/BE0^vn!GoW.ZaP6&mGo0tz3&BzaeQp;s<N+:_n_q6*bd"
+end
+
 environment :prod do
   set include_erts: true
   set include_src: false
@@ -31,7 +37,7 @@ end
 # will be used by default
 
 release :ib_gib_umb do
-  set version: "0.1.0"
+  set version: "0.1.1"
   set applications: [
     ib_gib: :permanent,
     random_gib: :permanent,


### PR DESCRIPTION
* Added forwarding config for nginx to include origin IP.
  * Not sure if this is quite what I need, but it does show
    "more of an originating" ip in the header.
    * It's showing the IP of the local docker-machine gateway
      when testing using virtualbox. I'm not sure if it will
      be the caller's IP or not when deployed to aws.
* :mouse: Tweaked `ib_gib_controller.ex` to look at new header
  instead of `conn.remote_ip`.
* I'm closing this for now, since it's "working" and I won't
  know until it is published that it is really working in prod.
  I will reopen if it continues to be incorrect.

issue: closes #84