### PR TITLE
Remembers URL when no session yet started

### DIFF
--- a/ib_gib_umb/apps/web_gib/lib/web_gib/constants.ex
+++ b/ib_gib_umb/apps/web_gib/lib/web_gib/constants.ex
@@ -13,6 +13,8 @@ defmodule WebGib.Constants do
       @ib_session_id_key "ib_session_id"
       @ib_session_ib_gib_key "ib_session_ib_gib"
 
+      @path_before_redirect_key "path_before_redirect"
+
       # key to array of identities associated with current ib_gib session,
       # stored in session.
       # See `WebGib.Plugs.IbGibIdentity`

--- a/ib_gib_umb/apps/web_gib/web/controllers/ib_gib_controller.ex
+++ b/ib_gib_umb/apps/web_gib/web/controllers/ib_gib_controller.ex
@@ -34,13 +34,25 @@ defmodule WebGib.IbGibController do
     _ = Logger.debug "conn: #{inspect conn}"
     _ = Logger.debug "index. params: #{inspect params}"
 
+    path_before_redirect = conn |> get_session(@path_before_redirect_key) |> URI.decode()
+    prefix = "/ibgib/"
+    {conn, target} =
+      if path_before_redirect == nil or !String.starts_with?(path_before_redirect, prefix) do
+        {conn, @root_ib_gib}
+      else
+        target_ibgib = String.replace(path_before_redirect, prefix, "")
+        Logger.debug("new target_ibgib: #{target_ibgib}" |> ExChalk.bg_blue)
+        conn = conn |> put_session(@path_before_redirect_key, nil)
+        {conn, target_ibgib}
+      end
+
     conn
     |> assign(:ib, "ib")
     |> assign(:gib, "gib")
-    |> assign(:ib_gib, @root_ib_gib)
+    |> assign(:ib_gib, target)
     |> add_meta_query
     # |> redirect(to: ib_gib_path(WebGib.Endpoint, :show, get_session(conn, @meta_query_result_ib_gib_key)))
-    |> redirect(to: ib_gib_path(WebGib.Endpoint, :show, @root_ib_gib))
+    |> redirect(to: ib_gib_path(WebGib.Endpoint, :show, target))
   end
 
   defp add_meta_query(conn) do

--- a/ib_gib_umb/apps/web_gib/web/plugs/ensure_ib_gib_session.ex
+++ b/ib_gib_umb/apps/web_gib/web/plugs/ensure_ib_gib_session.ex
@@ -34,7 +34,8 @@ defmodule WebGib.Plugs.EnsureIbGibSession do
     if current_ib_session == nil do
       _ = Logger.debug "current ib session is nil"
       conn
-      |> put_flash(:error, gettext "Please read ibGib's vision before using our application!")
+      |> put_flash(:error, gettext "Please read ibGib's Vision and Privacy Caution before continuing. Thanks :-)")
+      |> put_session(@path_before_redirect_key, conn.request_path)
       |> redirect(to: "/")
       |> halt
     else


### PR DESCRIPTION
See issue #88 

* Redirects the user to the original incoming URL (assuming it's an
  "/ibgib/someib^gib" form) after viewing the home page vision and
  privacy caution.

issue: closes #88