### PR TITLE
web_gib:high_heel::bug: Favicons fixed

### DIFF
--- a/ib_gib_umb/apps/web_gib/lib/web_gib/endpoint.ex
+++ b/ib_gib_umb/apps/web_gib/lib/web_gib/endpoint.ex
@@ -11,7 +11,7 @@ defmodule WebGib.Endpoint do
   # when deploying your static files in production.
   plug Plug.Static,
     at: "/", from: :web_gib, gzip: false,
-    only: ~w(css fonts images js files favicon.ico robots.txt)
+    only: ~w(css fonts images js files favicon.ico favicon-32x32.png favicon-16x16.png favicon-48x48.png apple-touch-icon.png manifest.json safari-pinned-tab.svg android-chrome-192x192.png android-chrome-512x512.png browserconfig.xml mstile-150x150.png robots.txt)
 
   plug Plug.Static,
     at: "files/", from: @upload_files_path, gzip: false


### PR DESCRIPTION
* Added root asset files in endpoint `Plug.Static`.
  * See #55 for more details.
* Cannot duplicate the 404s on css files.

issue: closes #55