### PR TITLE
web_gib:art::wrench::factory::high_heel::bug::mouse: mut8 comment, refactor, bugs, tweaks

### DIFF
--- a/ib_gib_umb/apps/web_gib/lib/web_gib/bus/commanding.ex
+++ b/ib_gib_umb/apps/web_gib/lib/web_gib/bus/commanding.ex
@@ -10,7 +10,8 @@ defmodule WebGib.Bus.Commanding do
 
   require Logger
 
-  alias WebGib.Bus.Commanding.{Fork, Comment, Refresh, BatchRefresh, Allow, GetAdjuncts}
+  alias WebGib.Bus.Commanding.{Fork, Comment, Refresh, BatchRefresh, Allow, GetAdjuncts, Mut8Comment}
+  import WebGib.Bus.Commanding.Helper
 
   def handle_cmd(cmd_name, data, metadata, msg, socket) do
     _ = Logger.debug("cmd_name: #{cmd_name}\ndata: #{inspect data}\nmetadata: #{inspect metadata}\nmsg: #{inspect msg}\nsocket: #{inspect socket}" |> ExChalk.bg_cyan |> ExChalk.red)
@@ -35,5 +36,12 @@ defmodule WebGib.Bus.Commanding do
   end
   defp handle_cmd_impl("getadjuncts", data,  metadata, msg, socket) do
     GetAdjuncts.handle_cmd(data, metadata, msg, socket)
+  end
+  defp handle_cmd_impl("mut8comment", data,  metadata, msg, socket) do
+    Mut8Comment.handle_cmd(data, metadata, msg, socket)
+  end
+  defp handle_cmd_impl(cmd_name, data, metadata, msg, socket) do
+    emsg = "Unknown command params. cmd_name: #{inspect cmd_name}"
+    handle_cmd_error(:error, emsg, msg, socket)
   end
 end

--- a/ib_gib_umb/apps/web_gib/lib/web_gib/bus/commanding/mut8_comment.ex
+++ b/ib_gib_umb/apps/web_gib/lib/web_gib/bus/commanding/mut8_comment.ex
@@ -1,0 +1,152 @@
+defmodule WebGib.Bus.Commanding.Mut8Comment do
+  @moduledoc """
+  Command-related code for the bus being implemented on Phoenix channels.
+
+  (Naming things is hard oy)
+
+  ## Why Comment on Latest Src - Reducing Branching Timelines
+
+  When we do a comment on a src, we get the latest version of the src first
+  and comment on _that_ src. This is to help reduce the possibility of
+  accidental branching timelines.
+
+  See
+  https://github.com/ibgib/ibgib/commit/4111df50e0c0c4530ae59163bb5c8edcca39cb37
+
+  When we move to a more distributed architecture, this will need to be
+  re-visited, because the most recent version would possibly differ, unless
+  we use a sharding approach, perhaps based on the temporal junction point of
+  an ibGib? Probably this would be best, or perhaps a sharding approach on the
+  given user identities. Either way, we need to have a single data store that
+  tracks a given timeline, otherwise branching timelines for a single ibGib
+  will abound.
+  """
+
+  require Logger
+
+  alias IbGib.Auth.Authz
+  alias WebGib.Bus.Channels.Event, as: EventChannel
+  alias WebGib.Adjunct
+  import IbGib.{Expression, Helper}
+  import WebGib.Bus.Commanding.Helper
+  use IbGib.Constants, :ib_gib
+
+  def handle_cmd(%{"comment_text" => comment_text,
+                    "src_ib_gib" => src_ib_gib} = data,
+                 _metadata,
+                 msg,
+                 %{assigns:
+                   %{ib_identity_ib_gibs: identity_ib_gibs}
+                 } = socket) do
+    _ = Logger.debug("yakker. src_ib_gib: #{src_ib_gib}" |> ExChalk.blue |> ExChalk.bg_white)
+    # Process.sleep(2000);
+    with(
+      # Validate
+      {:comment_text, true} <-
+        validate_input(:comment_text, comment_text, "Invalid comment text."),
+      {:src_ib_gib, true} <-
+        validate_input(:src_ib_gib, src_ib_gib, "Invalid source ibGib", :ib_gib),
+        {:ok, {src_ib, _src_gib}} <- separate_ib_gib(src_ib_gib),
+      {:src_ib_gib, true} <-
+        validate_input(:src_ib_gib,
+                       {:simple,  src_ib === "comment"},
+                       "Source must be a comment^gib."),
+
+      # Execute
+      {:ok, new_src_ib_gib} <-
+        exec_impl(identity_ib_gibs, src_ib_gib, comment_text),
+
+      # Broadcast update
+      {:ok, :ok} <- broadcast(src_ib_gib, new_src_ib_gib),
+
+      # Reply
+      {:ok, reply_msg} <- get_reply_msg(new_src_ib_gib)
+    ) do
+      {:reply, {:ok, reply_msg}, socket}
+    else
+      {:error, reason} when is_bitstring(reason) ->
+        handle_cmd_error(:error, reason, msg, socket)
+      {:error, reason} ->
+        handle_cmd_error(:error, inspect(reason), msg, socket)
+      error ->
+        handle_cmd_error(:error, inspect(error), msg, socket)
+    end
+  end
+
+  defp exec_impl(identity_ib_gibs, src_ib_gib, comment_text) do
+    with(
+      # Get **latest** src and reference to base comment_gib to use.
+      # See notes in module doc (`WebGib.Bus.Commanding.Comment`) for
+      # more info on why getting the latest src.
+      {:ok, latest_src} <- prepare(identity_ib_gibs, src_ib_gib),
+
+      # Mut8 the comment
+      {:ok, new_src} <-
+        mut8_comment(identity_ib_gibs, latest_src, comment_text),
+
+      # Get the corresponding ib^gibs to return
+      {:ok, new_src_ib_gib} <- get_ib_gibs(new_src)
+    ) do
+      {:ok, new_src_ib_gib}
+    else
+      error -> default_handle_error(error)
+    end
+  end
+
+  defp prepare(identity_ib_gibs, src_ib_gib) do
+    with(
+      {:ok, latest_src_ib_gib} <-
+        IbGib.Common.get_latest_ib_gib(identity_ib_gibs, src_ib_gib),
+      {:ok, latest_src} <-
+        IbGib.Expression.Supervisor.start_expression(latest_src_ib_gib)
+    ) do
+      {:ok, latest_src}
+    else
+      error -> default_handle_error(error)
+    end
+  end
+
+  # Creates the comment, only rel8ng it to src via comment_on rel8n.
+  defp mut8_comment(identity_ib_gibs, latest_src, comment_text) do
+    with(
+      state <- %{
+                  "text" => comment_text
+                  # "render" => "text",
+                  # "shape" => "rect"
+                },
+      {:ok, new_src} <- latest_src |> mut8(identity_ib_gibs, state)
+    ) do
+      {:ok, new_src}
+    else
+      error -> default_handle_error(error)
+    end
+  end
+
+  # Still pluralized because reusing from comment.ex command.
+  defp get_ib_gibs(new_src) do
+    with(
+      {:ok, new_src_info} <- get_info(new_src),
+      {:ok, new_src_ib_gib} <- get_ib_gib(new_src_info)
+    ) do
+      {:ok, new_src_ib_gib}
+    else
+      error -> default_handle_error(error)
+    end
+  end
+
+  defp broadcast(src_ib_gib, new_src_ib_gib) do
+    EventChannel.broadcast_ib_gib_event(:update,
+                                        {src_ib_gib, new_src_ib_gib})
+    {:ok, :ok}
+  end
+
+  defp get_reply_msg(new_src_ib_gib) do
+    reply_msg =
+      %{
+        "data" => %{
+          "new_src_ib_gib" => new_src_ib_gib
+        }
+      }
+    {:ok, reply_msg}
+  end
+end

--- a/ib_gib_umb/apps/web_gib/web/components/details/upload_pic.ex
+++ b/ib_gib_umb/apps/web_gib/web/components/details/upload_pic.ex
@@ -22,7 +22,7 @@ defmodule WebGib.Web.Components.Details.UploadPic do
         end
         div [class: "form-group"] do
           label "Select an image to upload: ", for: "pic_form_data_file"
-          input [id: "pic_form_data_file", name: "pic_form_data[pic_data]", class: "form-control", type: "file", required: "true"]
+          input [id: "pic_form_data_file", name: "pic_form_data[pic_data]", class: "form-control", type: "file", required: "true", accept: "image/*"]
         end
         div [class: "form-group"] do
           div [class: "ib-tooltip"] do

--- a/ib_gib_umb/apps/web_gib/web/static/js/d3params.js
+++ b/ib_gib_umb/apps/web_gib/web/static/js/d3params.js
@@ -201,9 +201,9 @@ var d3MenuCommands = [
     "color": "lightgray"
   },
   {
-    "id": "menu-mut8",
-    "name": "mut8",
-    "text": "Mut8",
+    "id": "menu-mut8comment",
+    "name": "mut8comment",
+    "text": "Mut8 Comment",
     "icon": "\u2622",
     "description": "The Mut8 button will allow you to edit the selected ibGib",
     "color": "lightblue"
@@ -357,4 +357,10 @@ var d3AddableRel8ns = [
   "pic",
 ]
 
-export { d3CircleRadius, d3LongPressMs, d3DblClickMs, d3LinkDistances, d3Scales, d3Colors, d3BoringRel8ns, d3AlwaysRel8ns, d3RequireExpandLevel2, d3MenuCommands, d3Rel8nIcons, d3RootUnicodeChar, d3AddableRel8ns };
+var d3PausedRel8ns = [
+  "past",
+  "dna"
+]
+
+export { d3CircleRadius, d3LongPressMs, d3DblClickMs, d3LinkDistances, d3Scales, d3Colors, d3BoringRel8ns, d3AlwaysRel8ns, d3RequireExpandLevel2, d3MenuCommands, d3Rel8nIcons, d3RootUnicodeChar, d3AddableRel8ns, d3PausedRel8ns };
+0

--- a/ib_gib_umb/apps/web_gib/web/static/js/graphs/dynamic-d3-force-graph.js
+++ b/ib_gib_umb/apps/web_gib/web/static/js/graphs/dynamic-d3-force-graph.js
@@ -1093,11 +1093,14 @@ export class DynamicD3ForceGraph {
   /**
    * Applies super-fun border transition effect to `nodeShape`.
    * If `nodeShape` is not given, then will selected it from `d.id`.
+   * @param type is color transition type. If `type` is not given, defaults to "rainbow". Possible values = "rainbow", "error"
    */
-  animateNodeBorder(d, nodeShape) {
+  animateNodeBorder(d, nodeShape, type) {
     let t = this;
 
     nodeShape = nodeShape ? nodeShape : d3.select("#" + t.getNodeShapeId(d));
+
+    let colorTransitions = t.getColorTransitions(type);
 
     var transition =
       d3.transition()
@@ -1106,29 +1109,45 @@ export class DynamicD3ForceGraph {
 
     nodeShape
       .transition(transition)
-      .attr("stroke", "red")
+      .attr("stroke", colorTransitions[0])
       .attr("stroke-width", "5px")
       .transition(transition)
-      .attr("stroke", "orange")
+      .attr("stroke", colorTransitions[1])
       .attr("stroke-width", "10px")
       .transition(transition)
-      .attr("stroke", "yellow")
+      .attr("stroke", colorTransitions[2])
       .attr("stroke-width", "15px")
       .transition(transition)
-      .attr("stroke", "green")
+      .attr("stroke", colorTransitions[3])
       .attr("stroke-width", "16px")
       .transition(transition)
-      .attr("stroke", "blue")
+      .attr("stroke", colorTransitions[4])
       .attr("stroke-width", "15px")
       .transition(transition)
-      .attr("stroke", "indigo")
+      .attr("stroke", colorTransitions[5])
       .attr("stroke-width", "10px")
       .transition(transition)
-      .attr("stroke", "violet")
+      .attr("stroke", colorTransitions[6])
       .attr("stroke-width", "5px")
       .transition(transition)
       .attr("stroke", d => t.getNodeBorderStroke(nodeShape.data()))
       .attr("stroke-width", t.getNodeBorderStrokeWidth(nodeShape.data()));
+  }
+
+
+  getColorTransitions(type) {
+    let rainbow = [
+      "red", "orange", "yellow", "green", "blue", "indigo", "violet"
+    ]
+    let error = [
+      "red", "red", "red", "red", "red", "red", "red"
+    ]
+
+    switch (type || "") {
+      case "rainbow": return rainbow;
+      case "error": return error;
+      default: return rainbow;
+    }
   }
 
   setBusy(d) {
@@ -1151,5 +1170,41 @@ export class DynamicD3ForceGraph {
       clearInterval(d.busyInterval);
       delete d.busyInterval;
     }
+  }
+
+  setErrored(d, clearAfterMsg, emsg) {
+    let t = this;
+
+    if (d.errored) {
+      return;
+    } else {
+      d.errored = true;
+      d.clearAfterMsg = clearAfterMsg;
+      d.emsg = emsg;
+      d.erroredInterval = setInterval(() => {
+        if (d.errored) {
+          t.animateNodeBorder(d, /*nodeShape*/ null, "error");
+        }
+      }, 1000);
+    }
+  }
+  clearErrored(d) {
+    if (d.errored) { delete d.errored; }
+    if (d.clearAfterMsg) { delete d.clearAfterMsg; }
+    if (d.emsg) { delete d.emsg; }
+    if (d.erroredInterval) {
+      clearInterval(d.erroredInterval);
+      delete d.erroredInterval;
+    }
+  }
+
+  highlightNode(d, type, durationMs) {
+    let t = this;
+    let start = Date.now();
+    let interval = setInterval(() => {
+      let elapsed = Date.now() - start;
+      if (elapsed >= durationMs) { clearInterval(interval); }
+      t.animateNodeBorder(d, /*nodeShape*/ null, type);
+    }, 1000);
   }
 }

--- a/ib_gib_umb/apps/web_gib/web/static/js/graphs/dynamic-ib-scape-menu.js
+++ b/ib_gib_umb/apps/web_gib/web/static/js/graphs/dynamic-ib-scape-menu.js
@@ -7,6 +7,7 @@ import { DynamicD3ForceGraph } from './dynamic-d3-force-graph';
 import * as commands from '../services/commanding/commands';
 import { CommandManager } from '../services/commanding/command-manager';
 import * as ibHelper from '../services/ibgib-helper';
+import * as ibAuthz from '../services/ibgib-authz';
 
 export class DynamicIbScapeMenu extends DynamicD3ForceGraph {
   constructor(graphDiv, svgId, config, ibScape, d, position) {
@@ -153,6 +154,8 @@ export class DynamicIbScapeMenu extends DynamicD3ForceGraph {
    * "merge", etc.
    */
   getMenuCommandsJson(d) {
+    let t = this;
+    
     // TODO: ib-scape.js getMenuCommandsJson: When we have client-side dynamicism (prefs, whatever), then we need to change this to take that into account when building the popup menu.
     let commands;
 
@@ -175,6 +178,9 @@ export class DynamicIbScapeMenu extends DynamicD3ForceGraph {
       }
       if (d.cat === "link") {
         commands.push("externallink");
+      }
+      if (ibHelper.isComment(d.ibGibJson) && ibAuthz.isAuthorizedForMut8OrRel8(d.ibGibJson, t.ibScape.currentIdentityIbGibs)) {
+        commands.push("mut8comment");
       }
     }
 

--- a/ib_gib_umb/apps/web_gib/web/static/js/services/commanding/command-manager.js
+++ b/ib_gib_umb/apps/web_gib/web/static/js/services/commanding/command-manager.js
@@ -61,6 +61,9 @@ export class CommandManager {
       case "comment":
         t.ibScape.currentCmd = t.getCommand_Comment(dIbGib);
         break;
+      case "mut8comment":
+        t.ibScape.currentCmd = t.getCommand_Mut8Comment(dIbGib);
+        break;
       case "identemail":
         t.ibScape.currentCmd = t.getCommand_IdentEmail(dIbGib);
         break;
@@ -116,6 +119,9 @@ export class CommandManager {
     switch (dIbGib.rel8nName) {
       case "comment":
         return t.getCommand_Comment(dIbGib.rel8nSrc);
+        break;
+      case "mut8comment":
+        return t.getCommand_Mut8Comment(dIbGib.rel8nSrc);
         break;
       case "pic":
         return t.getCommand_Pic(dIbGib.rel8nSrc);
@@ -199,6 +205,9 @@ export class CommandManager {
   }
   getCommand_Comment(dIbGib) {
     return new commands.CommentDetailsCommand(this.ibScape, dIbGib);
+  }
+  getCommand_Mut8Comment(dIbGib) {
+    return new commands.Mut8CommentDetailsCommand(this.ibScape, dIbGib);
   }
   getCommand_IdentEmail(dIbGib) {
     return new commands.IdentEmailDetailsCommand(this.ibScape, dIbGib);

--- a/ib_gib_umb/apps/web_gib/web/static/js/services/ibgib-authz.js
+++ b/ib_gib_umb/apps/web_gib/web/static/js/services/ibgib-authz.js
@@ -1,0 +1,134 @@
+import * as ibHelper from './ibgib-helper';
+
+/**
+ * Checks to see if the given `currentIdentityIbGibs` are authorized to Perform
+ * an `AllowCommand` on the `targetIbGibJson`.
+ *
+ * This is my only authorization function, so I'm just putting it in this
+ * helper file for now. In the future, however, we should refactor this into its
+ * own authorization module. This is especially true since the amount of
+ * server-side code duplicated on the client will grow as we want to increase
+ * distributed and disconnected processing, eventually to the point of
+ * "duplicating" the engine. (It does not have to be an actual duplicate per se,
+ * rather it should be able to have ib^gib addresses with data and hashes that
+ * can interoperate with.)
+ */
+export function isAuthorizedForMut8OrRel8(targetIbGibJson, currentIdentityIbGibs) {
+  let t = this;
+
+  let targetIdentityIbGibs = ibHelper.getIdentityIbGibs(targetIbGibJson);
+  let targetAuthTier = _getHighestAuthTier(targetIdentityIbGibs);
+  let targetTierValue = _tierValues[targetAuthTier];
+
+  let currentAuthTier = _getHighestAuthTier(currentIdentityIbGibs);
+  let currentTierValue = _tierValues[currentAuthTier];
+
+  if (targetTierValue > currentTierValue) {
+    // The target requires a higher level of authorization.
+    return false; // unauthorized
+
+  } else if (targetTierValue === 0) {
+    // We're trying to allow an adjunct to an ibGib with only the root ib^gib
+    // as its identity? That doesn't sound right, but I'm not 100% - we'll see.
+    console.error(`${lc} error: cannot allow adjunct to a target with no authorization tier.`);
+    return false; // unauthorized
+
+  } else if (targetAuthTier === "session") {
+    return _isAuthorizedForMut8OrRel8_Session(targetIdentityIbGibs, currentIdentityIbGibs);
+
+  } else if (targetAuthTier === "email") {
+    return _isAuthorizedForMut8OrRel8_Email(targetIdentityIbGibs, currentIdentityIbGibs);
+
+  } else {
+    // huh? How'd we get here? Should be logical impossibility.
+    console.error(`${lc} My logic is bad...how'd we get here? targetAuthTier: ${targetAuthTier}. currentAuthTier: ${currentAuthTier}`);
+    return false; // unauthorized
+  }
+}
+
+function _isAuthorizedForMut8OrRel8_Session(targetIdentityIbGibs, currentIdentityIbGibs) {
+  let lc = `_isAuthorizedForMut8OrRel8_Session`;
+
+  // Usually (always?) there will be only one session. But regardless, if the
+  // highest level is session, then only one of them has to match to be
+  // authorized.
+  let authorized =
+    targetIdentityIbGibs
+      .filter(targetIdentityIbGib => targetIdentityIbGib !== "ib^gib")
+      .reduce((authorized, targetIdentityIbGib) => {
+        if (authorized) {
+          // bypass further checking since we know we're authorized
+          return true;
+        } else {
+          // not yet authorized, so check if targetIdentityIbGib is included
+          // in currentIdentityIbGibs
+          return currentIdentityIbGibs.includes(targetIdentityIbGib);
+        }
+      }, false);
+
+    // console.log(`${lc} authorized: ${authorized}. (requires one) targetIdentityIbGibs: ${JSON.stringify(targetIdentityIbGibs)}. (actual) currentIdentityIbGibs: ${JSON.stringify(currentIdentityIbGibs)}`);
+
+    return authorized;
+}
+
+function _isAuthorizedForMut8OrRel8_Email(targetIdentityIbGibs, currentIdentityIbGibs) {
+  let lc = `_isAuthorizedForMut8OrRel8_Email`;
+
+  // only email identityIbGibs matter at "email" auth tier
+  let targetIdentityIbGibs_Email =
+    targetIdentityIbGibs
+      .filter(identityIbGib => _getIdentityType(identityIbGib) === "email");
+
+  // All target email identities must be present in the current identity ibGibs.
+  let authorized =
+    targetIdentityIbGibs_Email
+      .every(targetIdentityIbGib => currentIdentityIbGibs.includes(targetIdentityIbGib));
+
+  console.log(`${lc} authorized: ${authorized}. (requires all) targetIdentityIbGibs: ${JSON.stringify(targetIdentityIbGibs)}. (actual) currentIdentityIbGibs: ${JSON.stringify(currentIdentityIbGibs)}`);
+
+  return authorized;
+}
+
+const _tierValues = {
+  "ibgib": 0,
+  "session": 1,
+  "email": 2
+}
+// easier to just invert than anything fancy
+const _tierValues_ByValue = {
+  0: "ibgib",
+  1: "session",
+  2: "email"
+}
+
+function _getHighestAuthTier(identityIbGibs) {
+  let lc = `_getHighestAuthTier`;
+
+  let tierValue = identityIbGibs.reduce((highestTierValue, identityIbGib) => {
+    let identityType = _getIdentityType(identityIbGib);
+    let tierValue = _tierValues[identityType];
+    return tierValue > highestTierValue ? tierValue : highestTierValue;
+  }, 0);
+
+  let highestAuthTier = _tierValues_ByValue[tierValue];
+
+  // console.log(`${lc} highestAuthTier: ${highestAuthTier}. identityIbGibs: ${JSON.stringify(identityIbGibs)}`);
+
+  return highestAuthTier;
+}
+
+function _getIdentityType(identityIbGib) {
+  let lc = `_getIdentityType(${identityIbGib})`;
+
+  if (identityIbGib === "ib^gib") {
+    return "ibgib";
+  } else {
+    const identityTypeDelim = "_"
+    let identityIb = ibHelper.getIbAndGib(identityIbGib).ib;
+    let [identityType, _rest] = identityIb.split(identityTypeDelim);
+
+    // console.log(`${lc} identityIb: ${identityIb}. identityType: ${identityType}`);
+
+    return identityType;
+  }
+}

--- a/ib_gib_umb/apps/web_gib/web/static/js/services/ibgib-helper.js
+++ b/ib_gib_umb/apps/web_gib/web/static/js/services/ibgib-helper.js
@@ -91,135 +91,23 @@ export function getIdentityIbGibs(ibGibJson) {
   return ibGibJson.rel8ns.identity;
 }
 
-/**
- * Checks to see if the given `currentIdentityIbGibs` are authorized to Perform
- * an `AllowCommand` on the `adjunctTargetIbGibJson`.
- *
- * This is my only authorization function, so I'm just putting it in this
- * helper file for now. In the future, however, we should refactor this into its
- * own authorization module. This is especially true since the amount of
- * server-side code duplicated on the client will grow as we want to increase
- * distributed and disconnected processing, eventually to the point of
- * "duplicating" the engine. (It does not have to be an actual duplicate per se,
- * rather it should be able to have ib^gib addresses with data and hashes that
- * can interoperate with.)
- */
-export function isAuthorizedToAllow(adjunctTargetIbGibJson, currentIdentityIbGibs) {
-  let t = this;
+export function isComment(ibGibJson) {
+  let result = false;
 
-  let targetIdentityIbGibs = getIdentityIbGibs(adjunctTargetIbGibJson);
-  let targetAuthTier = _getHighestAuthTier(targetIdentityIbGibs);
-  let targetTierValue = _tierValues[targetAuthTier];
-
-  let currentAuthTier = _getHighestAuthTier(currentIdentityIbGibs);
-  let currentTierValue = _tierValues[currentAuthTier];
-
-  if (targetTierValue > currentTierValue) {
-    // The target requires a higher level of authorization.
-    return false; // unauthorized
-
-  } else if (targetTierValue === 0) {
-    // We're trying to allow an adjunct to an ibGib with only the root ib^gib
-    // as its identity? That doesn't sound right, but I'm not 100% - we'll see.
-    console.error(`${lc} error: cannot allow adjunct to a target with no authorization tier.`);
-    return false; // unauthorized
-
-  } else if (targetAuthTier === "session") {
-    return _isAuthorizedToAllow_Session(targetIdentityIbGibs, currentIdentityIbGibs);
-
-  } else if (targetAuthTier === "email") {
-    return _isAuthorizedToAllow_Email(targetIdentityIbGibs, currentIdentityIbGibs);
-
+  if (ibGibJson.ib === "comment") {
+    result = true;
   } else {
-    // huh? How'd we get here? Should be logical impossibility.
-    console.error(`${lc} My logic is bad...how'd we get here? targetAuthTier: ${targetAuthTier}. currentAuthTier: ${currentAuthTier}`);
-    return false; // unauthorized
+    // check the ancestry to see if those are comments, because
+    // maybe this comment has just been forked.
+    let ancestors = ibGibJson.rel8ns["ancestor"];
+    for (var i = 0; i < ancestors.length; i++) {
+      let { ancestorIb } = getIbAndGib(ancestors[i]);
+      if (ancestorIb === "comment" && ibGibJson.data.text) {
+        result = true;
+        break;
+      }
+    }
   }
-}
 
-function _isAuthorizedToAllow_Session(targetIdentityIbGibs, currentIdentityIbGibs) {
-  let lc = `_isAuthorizedToAllow_Session`;
-
-  // Usually (always?) there will be only one session. But regardless, if the
-  // highest level is session, then only one of them has to match to be
-  // authorized.
-  let authorized =
-    targetIdentityIbGibs
-      .filter(targetIdentityIbGib => targetIdentityIbGib !== "ib^gib")
-      .reduce((authorized, targetIdentityIbGib) => {
-        if (authorized) {
-          // bypass further checking since we know we're authorized
-          return true;
-        } else {
-          // not yet authorized, so check if targetIdentityIbGib is included
-          // in currentIdentityIbGibs
-          return currentIdentityIbGibs.includes(targetIdentityIbGib);
-        }
-      }, false);
-
-    // console.log(`${lc} authorized: ${authorized}. (requires one) targetIdentityIbGibs: ${JSON.stringify(targetIdentityIbGibs)}. (actual) currentIdentityIbGibs: ${JSON.stringify(currentIdentityIbGibs)}`);
-
-    return authorized;
-}
-
-function _isAuthorizedToAllow_Email(targetIdentityIbGibs, currentIdentityIbGibs) {
-  let lc = `_isAuthorizedToAllow_Email`;
-
-  // only email identityIbGibs matter at "email" auth tier
-  let targetIdentityIbGibs_Email =
-    targetIdentityIbGibs
-      .filter(identityIbGib => _getIdentityType(identityIbGib) === "email");
-
-  // All target email identities must be present in the current identity ibGibs.
-  let authorized =
-    targetIdentityIbGibs_Email
-      .every(targetIdentityIbGib => currentIdentityIbGibs.includes(targetIdentityIbGib));
-
-  console.log(`${lc} authorized: ${authorized}. (requires all) targetIdentityIbGibs: ${JSON.stringify(targetIdentityIbGibs)}. (actual) currentIdentityIbGibs: ${JSON.stringify(currentIdentityIbGibs)}`);
-
-  return authorized;
-}
-
-const _tierValues = {
-  "ibgib": 0,
-  "session": 1,
-  "email": 2
-}
-// easier to just invert than anything fancy
-const _tierValues_ByValue = {
-  0: "ibgib",
-  1: "session",
-  2: "email"
-}
-
-function _getHighestAuthTier(identityIbGibs) {
-  let lc = `_getHighestAuthTier`;
-
-  let tierValue = identityIbGibs.reduce((highestTierValue, identityIbGib) => {
-    let identityType = _getIdentityType(identityIbGib);
-    let tierValue = _tierValues[identityType];
-    return tierValue > highestTierValue ? tierValue : highestTierValue;
-  }, 0);
-
-  let highestAuthTier = _tierValues_ByValue[tierValue];
-
-  // console.log(`${lc} highestAuthTier: ${highestAuthTier}. identityIbGibs: ${JSON.stringify(identityIbGibs)}`);
-
-  return highestAuthTier;
-}
-
-function _getIdentityType(identityIbGib) {
-  let lc = `_getIdentityType(${identityIbGib})`;
-
-  if (identityIbGib === "ib^gib") {
-    return "ibgib";
-  } else {
-    const identityTypeDelim = "_"
-    let identityIb = getIbAndGib(identityIbGib).ib;
-    let [identityType, _rest] = identityIb.split(identityTypeDelim);
-
-    // console.log(`${lc} identityIb: ${identityIb}. identityType: ${identityType}`);
-
-    return identityType;
-  }
+  return result;
 }


### PR DESCRIPTION
* :wrench: Implemented mut8 comment.
  * Client side.
    * Created `Mut8CommentDetailsCommand`.
      * Reuses form from comment cmd.
        * Restructured class functions a little to accommodate this.
        * Added `sanitizeFormFields` in order trim whitespace.
      * Created `ibScape.setErrored` function so we can just flash
        a red border instead of rainbow using similar functionality
        to the `setBusy` function.
  * Server side
    * Created `WebGib.Bus.Commanding.Mut8Comment`.
      * Much like the `WebGib.Bus.Commanding.Comment` counterpart
        but tweaked.
* :factory: Refactored authorization functions on js side to re-use
  the code from the `Allow` command js authorization.
  * Brought out authz code into its own js file.
  * Renamed functions.
* :high_heel::bug: Squashed several bugs...
  * Continually blinking add command node.
  * Incorrect error handling when pic upload fails.
  * Problems with auto-expand causing inability to expand again.
  * Others (I think)...
* :mouse: Other tweaks.

issue: closes #85