### PR TITLE
Old-time ibgib refresh bug

### DIFF
--- a/ib_gib_umb/apps/web_gib/web/static/js/graphs/dynamic-ib-scape.js
+++ b/ib_gib_umb/apps/web_gib/web/static/js/graphs/dynamic-ib-scape.js
@@ -300,6 +300,13 @@ export class DynamicIbScape extends DynamicD3ForceGraph {
   }
   refreshIbGibs(ibGibs, callback) {
     let t = this, lc = `refreshIbGibs(ibGibs: ${JSON.stringify(ibGibs)})`;
+    if (t.busyRefreshing) {
+      let intervalClosure = setTimeout(() => {
+        t.refreshIbGibs(ibGibs, callback);
+      }, 5000);
+    } else {
+      t.busyRefreshing = true;
+    }
 
     t.backgroundRefresher.exec(ibGibs, successMsg => {
       // console.log(`${lc} Initial refresh source nodes complete. successMsg: ${JSON.stringify(successMsg)}`);
@@ -318,9 +325,13 @@ export class DynamicIbScape extends DynamicD3ForceGraph {
         } else {
           console.error(`${lc} successMsg.data problem.`);
         }
+        
+        delete t.busyRefreshing;
+        
         if (callback) { callback(); }
     }, errorMsg => {
       console.error(`Error on refresh ibGibs. errorMsg: ${JSON.stringify(errorMsg)}`);
+      if (t.busyRefreshing) { delete t.busyRefreshing; }
       if (callback) { callback(); }
     });
   }

--- a/ib_gib_umb/apps/web_gib/web/static/js/services/ibgib-helper.js
+++ b/ib_gib_umb/apps/web_gib/web/static/js/services/ibgib-helper.js
@@ -16,11 +16,22 @@ export function getIbAndGib(ibGib) {
 /**
  * Returns the first non-root ib^gib in the given ibGibJson past.
  * If there are no previous ib^gib in the past besides the root ib^gib, then
- * this returns
+ * this returns the current ibGib (i.e. "no past", so return the present)
  */
 export function getTemporalJunctionIbGib(ibGibJson) {
-  let past = ibGibJson.rel8ns.past;
-  return past.length > 1 ? past[1] : getFull_ibGib(ibGibJson);
+  // makes a copy, splice off the head which is the root (and never the temporal junction point)
+  let past = ibGibJson.rel8ns.past.concat().splice(1); 
+  
+  if (isImage(ibGibJson) || isComment(ibGibJson) || isLink(ibGibJson)) {
+    // We need special handling for pics, comments, links, because the first
+    // non-root in the history is actually a "blank", with empty `data`. So,
+    // in older versions, it is the same thing. In the current version they're
+    // unique, but we don't want to count on that at the moment. So we'll just 
+    // ignore this first "blank" anyway
+    past = past.splice(1);
+  }
+  
+  return past.length > 0 ? past[0] : getFull_ibGib(ibGibJson);
 }
 
 /** For safe access to ibGibJson.data.text */


### PR DESCRIPTION
* The problem was that the temporal junction point for pics, comments, links,
  points to a "blank" ibGib where the `data` value is empty. This is because
  when a pic is first created (e.g.), it forks the pic^gib and _then_ mut8s
  the data for the pic. This makes sense of course.
  * In the future (at some point), may need a manual pointer to the TJP.

issue: closes #143