### PR TITLE
Issue 35 identity ux and unidentify

### DIFF
--- a/ib_gib_umb/apps/web_gib/lib/web_gib/constants.ex
+++ b/ib_gib_umb/apps/web_gib/lib/web_gib/constants.ex
@@ -82,6 +82,7 @@ defmodule WebGib.Constants do
       @emsg_email_send_failed "There were problems sending the login email."
       @emsg_ident_email_failed "There was a problem with the login process."
       @emsg_ident_email_token_mismatch "The token does not match."
+      @emsg_unident_email_failed "There was a problem with the logout process."
 
       @emsg_could_not_create_thumbnail "There was a problem creating the thumbnail."
     end

--- a/ib_gib_umb/apps/web_gib/web/components/details/link.ex
+++ b/ib_gib_umb/apps/web_gib/web/components/details/link.ex
@@ -33,7 +33,7 @@ defmodule WebGib.Web.Components.Details.Link do
                value: ""]
         input [name: "_csrf_token", type: "hidden", value: Phoenix.Controller.get_csrf_token]
         div [class: "ib-tooltip"] do
-          button [type: "submit"] do
+          button [id: "ib-link-details-submit", type: "submit"] do
             span [class: "ib-center-glyph glyphicon glyphicon-link ib-green"]
           # span [class: "ib-tooltiptext"], do: gettext("Add Link")
           end

--- a/ib_gib_umb/apps/web_gib/web/components/details/un_ident_email.ex
+++ b/ib_gib_umb/apps/web_gib/web/components/details/un_ident_email.ex
@@ -1,0 +1,48 @@
+defmodule WebGib.Web.Components.Details.UnIdentEmail do
+  @moduledoc """
+  This contains the unident (email) details view, shown when the user clicks the
+  unidentemail menu command.
+  """
+
+  use Marker
+
+  use WebGib.MarkerElements
+  import WebGib.Gettext
+
+  use IbGib.Constants, :validation
+  use WebGib.Constants, :validation
+
+  component :un_ident_email_details do
+
+    # UnIdent (Email) details
+    div [id: "ib-unidentemail-details", class: "ib-details-off"] do
+      form [id: "ib-unidentemail-details-form", action: "/ibgib/ident", method: "post"] do
+        input [name: "_utf8", type: "hidden", value: "✓"]
+        input [id: "unidentemail_form_data_src_ib_gib", name: "unidentemail_form_data[src_ib_gib]", type: "hidden", value: ""]
+        # input [id: "unidentemail_form_data_email_addr", name: "unidentemail_form_data[email_addr]", type: "hidden", value: ""]
+        input [name: "unidentemail_form_data[ident_type]", type: "hidden", value: "email"]
+        p do
+          "Remove " 
+          span [id: "unidentemail_form_data_email_addr", class: "ib-bold"]
+          " from your current identification?"
+        end
+
+        input [name: "_csrf_token", type: "hidden", value: Phoenix.Controller.get_csrf_token]
+        div [id: "ib-unidentemail-details-submit", class: "ib-tooltip"] do
+          button [id: "ib-unidentemail-details-submit-btn", type: "submit"] do
+            span [class: "ib-center-glyph glyphicon glyphicon-envelope ib-green ib-left-icon-span"]
+            span [class: "ib-center-glyph glyphicon glyphicon-log-out ib-green"]
+          end
+        end
+        
+        br
+        
+        p [id: "ib-unidentemail-details-note"] do
+          "Note: This will not log out any other email address(es) you are identified by."
+        end
+      end
+    end
+
+  end
+
+end

--- a/ib_gib_umb/apps/web_gib/web/components/ib_scape.ex
+++ b/ib_gib_umb/apps/web_gib/web/components/ib_scape.ex
@@ -8,7 +8,7 @@ defmodule WebGib.Web.Components.IbScape do
 
   use WebGib.MarkerElements
   import WebGib.Gettext
-  import WebGib.Web.Components.Details.{Fork, Help, Comment, UploadPic, Link, IdentEmail, Info, Query, Download, Huh}
+  import WebGib.Web.Components.Details.{Fork, Help, Comment, UploadPic, Link, IdentEmail, UnIdentEmail, Info, Query, Download, Huh}
 
   component :ib_scape do
 
@@ -29,6 +29,7 @@ defmodule WebGib.Web.Components.IbScape do
         upload_pic_details
         link_details
         ident_email_details
+        un_ident_email_details
         info_details
         query_details
         download_details

--- a/ib_gib_umb/apps/web_gib/web/controllers/ib_gib_controller.ex
+++ b/ib_gib_umb/apps/web_gib/web/controllers/ib_gib_controller.ex
@@ -1039,6 +1039,56 @@ defmodule WebGib.IbGibController do
   # "log" invalid login attempts as well.
   # ----------------------------------------------------------------------------
 
+  defpat unidentemail_form_data_(
+    src_ib_gib_()
+  )
+
+  def unident(conn, %{"unidentemail_form_data" => unidentemail_form_data_(...) = form_data} = params) do
+    with(
+      {:ok, {conn, new_identity_ib_gibs}} <- remove_identity_from_session(conn, src_ib_gib)
+    ) do
+      conn
+      |> send_resp(200, "ok")
+    else
+      {:error, reason} ->
+        _ = Logger.error reason
+        # This still sends the status 
+        conn
+        |> send_resp(500, reason)
+        |> halt()
+        
+      error -> 
+        _ = Logger.error(inspect error)
+        conn
+        |> send_resp(500, inspect error)
+        |> halt()
+    end
+  end
+
+  # idempotent removal of identity_ib_gib from connection session.
+  defp remove_identity_from_session(conn, identity_ib_gib)
+    when identity_ib_gib !== @root_ib_gib do
+    with(
+      _ <- Logger.debug("BEFORE conn: #{inspect conn}\nidentity_ib_gib: #{identity_ib_gib}" |> ExChalk.bg_blue |> ExChalk.yellow),
+      
+      identity_ib_gibs <- conn |> get_session(@ib_identity_ib_gibs_key),
+      new_identity_ib_gibs <- 
+        identity_ib_gibs 
+        |> Enum.filter(&(&1 !== identity_ib_gib)),
+      
+      conn <-
+        conn
+        |> put_session(@ib_identity_ib_gibs_key, new_identity_ib_gibs),
+
+      _ <- Logger.debug("AFTER conn: #{inspect conn}\nidentity_ib_gib: #{identity_ib_gib}" |> ExChalk.bg_blue |> ExChalk.yellow)
+    ) do
+      {:ok, {conn, new_identity_ib_gibs}}
+    else
+      {:error, reason} when is_bitstring(reason) -> {:error, reason}
+      {:error, reason} -> {:error, inspect reason}
+      error -> {:error, inspect error}
+    end
+  end
 
   # Email identity clause
   def ident(conn,

--- a/ib_gib_umb/apps/web_gib/web/controllers/ib_gib_controller.ex
+++ b/ib_gib_umb/apps/web_gib/web/controllers/ib_gib_controller.ex
@@ -1045,7 +1045,19 @@ defmodule WebGib.IbGibController do
 
   def unident(conn, %{"unidentemail_form_data" => unidentemail_form_data_(...) = form_data} = params) do
     with(
-      {:ok, {conn, new_identity_ib_gibs}} <- remove_identity_from_session(conn, src_ib_gib)
+      {:ok, {conn, new_identity_ib_gibs}} <- 
+        remove_identity_from_session(conn, src_ib_gib),
+
+      session_identity_ib_gib <-
+        conn |> get_session(@ib_session_ib_gib_key),
+        # publish
+      _ <- EventChannel.broadcast_ib_gib_event(:unident_email,
+                                              {session_identity_ib_gib,
+                                               src_ib_gib})
+      # # publish
+      # _ <- EventChannel.broadcast_ib_gib_event(:unident_email,
+      #                                          {session_identity_ib_gib,
+      #                                           src_ib_gib})
     ) do
       conn
       |> send_resp(200, "ok")

--- a/ib_gib_umb/apps/web_gib/web/router.ex
+++ b/ib_gib_umb/apps/web_gib/web/router.ex
@@ -40,6 +40,7 @@ defmodule WebGib.Router do
     post "/pic", IbGibController, :pic
     post "/link", IbGibController, :link
     post "/ident", IbGibController, :ident
+    post "/unident", IbGibController, :unident
     post "/query", IbGibController, :query
   end
 

--- a/ib_gib_umb/apps/web_gib/web/static/css/app.scss
+++ b/ib_gib_umb/apps/web_gib/web/static/css/app.scss
@@ -56,6 +56,10 @@
   font-weight: bold;
 }
 
+.ib-italic {
+  font-style: italic;
+}
+
 .ib-pos-abs {
   position: absolute;
 }
@@ -384,4 +388,10 @@ ul {
   width: 100%;
   max-width: 560px;
   height: 315px;
+}
+
+#VimFxMarkersContainer .marker {
+  font-size: 12px !important; /* Specific font size. */
+  text-transform: lowercase !important; /* Lowercase text. */
+  opacity: 0.5 !important; /* Semi-transparent. Warning: Might be slow! */
 }

--- a/ib_gib_umb/apps/web_gib/web/static/css/d3related.scss
+++ b/ib_gib_umb/apps/web_gib/web/static/css/d3related.scss
@@ -245,3 +245,31 @@ div.panel {
     overflow: hidden;
     transition: max-height 0.6s ease-out;
 }
+
+#ib-link-details {
+  margin-top: 15px;
+}
+
+#link_form_data_text {
+  margin-bottom: 8px;
+  width: 100%;
+}
+
+#ib-link-details-submit {
+  padding-left: 10px;
+  padding-right: 10px;
+  padding-bottom: 4px;
+}
+
+// I'm creating this when combining two spans for "combo icons".
+// In the unidentify details view, i want to have a button with two icons on it.
+// So that button has two spans, and I need the two spans formatted properly.
+.ib-left-icon-span {
+  margin-right: 5px;
+}
+
+#ib-unidentemail-details-note {
+  margin-top: 10px;
+  font-style: italic;
+  font-size: 0.8em;
+}

--- a/ib_gib_umb/apps/web_gib/web/static/js/d3params.js
+++ b/ib_gib_umb/apps/web_gib/web/static/js/d3params.js
@@ -208,8 +208,17 @@ var d3MenuCommands = [
     "name": "identemail",
     "text": "Identify",
     "icon": "\uf090",
-    "description": "This lets you identify yourself with an email address",
+    "description": "This lets you identify yourself with an email address, which will be associated with all ibGib you create.",
     "color": "#FFFFFF",
+    "huh": huhText_Cmd_IdentEmail
+  },
+  {
+    "id": "menu-unidentemail",
+    "name": "unidentemail",
+    "text": "Un-Identify",
+    "icon": "\uf08b",
+    "description": "Logs OUT this email address, so that you will no longer be identified with it when creating ibGib. Any other email address(es) will stay logged in!",
+    "color": "#7D7D7D",
     "huh": huhText_Cmd_IdentEmail
   },
   {

--- a/ib_gib_umb/apps/web_gib/web/static/js/d3params.js
+++ b/ib_gib_umb/apps/web_gib/web/static/js/d3params.js
@@ -327,6 +327,7 @@ var d3MenuCommands = [
 
 let d3Rel8nIcons = {
   "identity": "\uf007",
+  "current identity": "\uf007",
   "pic": "\uf03e",
   "comment": "\uf075",
   "past": "\uf100",

--- a/ib_gib_umb/apps/web_gib/web/static/js/graphs/dynamic-ib-scape-menu.js
+++ b/ib_gib_umb/apps/web_gib/web/static/js/graphs/dynamic-ib-scape-menu.js
@@ -190,6 +190,11 @@ export class DynamicIbScapeMenu extends DynamicD3ForceGraph {
           commands.push("mut8comment");
         }
       }
+      
+      if (t.ibScape.currentIdentityIbGibs.includes(d.ibGib) &&
+          ibAuthz.isEmailIdentity(d.ibGibJson)) {
+        commands.push("unidentemail");
+      }
     }
 
 

--- a/ib_gib_umb/apps/web_gib/web/static/js/graphs/dynamic-ib-scape.js
+++ b/ib_gib_umb/apps/web_gib/web/static/js/graphs/dynamic-ib-scape.js
@@ -2660,11 +2660,17 @@ export class DynamicIbScape extends DynamicD3ForceGraph {
   handleEventBusMsg_Identity(identityIbGib, msg) {
     let t = this, lc = `handleEventBusMsg_Identity(${identityIbGib})`;
 
-    if (!t.currentIdentityIbGibs.includes(identityIbGib)) {
-      console.log(`Adding identityIbGib to currentIdentityIbGibs`);
-      t.currentIdentityIbGibs.push(identityIbGib);
+    if (msg.metadata.name === "ident_email") {
+      console.log(`ident_email msg: ${JSON.stringify(msg)}`)
+    } else if (msg.metadata.name === "unident_email") {
+      console.log(`unident_email msg: ${JSON.stringify(msg)}`)
+    } else {
+      console.error(`Unknown identity msg. identityIbGib: ${identityIbGib}. msg: ${JSON.stringify(msg)}`)
     }
 
+    // reload the entire app to ensure that we start fresh from the current
+    // identities in the connection cookie.
+    
     // Thanks SO! http://stackoverflow.com/a/28171425/4275029
     setTimeout(() => window.location.reload());
   }

--- a/ib_gib_umb/apps/web_gib/web/static/js/graphs/dynamic-ib-scape.js
+++ b/ib_gib_umb/apps/web_gib/web/static/js/graphs/dynamic-ib-scape.js
@@ -2668,6 +2668,4 @@ export class DynamicIbScape extends DynamicD3ForceGraph {
     // Thanks SO! http://stackoverflow.com/a/28171425/4275029
     setTimeout(() => window.location.reload());
   }
-  
-  
 }

--- a/ib_gib_umb/apps/web_gib/web/static/js/graphs/dynamic-ib-scape.js
+++ b/ib_gib_umb/apps/web_gib/web/static/js/graphs/dynamic-ib-scape.js
@@ -212,7 +212,7 @@ export class DynamicIbScape extends DynamicD3ForceGraph {
   initRoot() {
     let t = this;
     t.rootPos = {x: t.center.x, y: t.center.y};
-    t.addRootNode();
+    t.showRootNode();
   }
   initBackgroundRefresher() {
     let t = this;
@@ -959,8 +959,14 @@ export class DynamicIbScape extends DynamicD3ForceGraph {
     let node = t.addVirtualNode(t.getUniqueId(`${dSrc.id}_${rel8nName}`), /*type*/ "rel8n", `rel8n^gib`, /*srcNode*/ dSrc, "circle", /*autoZap*/ false, fadeTimeoutMs, /*cmd*/ null, title, /*label*/ rel8nName, /*startPos*/ {x: dSrc.x, y: dSrc.y}, /*isAdjunct*/ false);
     node.rel8nSrc = dSrc;
     node.parentNode = dSrc;
+    
+    if (dSrc.isMeta) { node.isMeta = true; }
 
     return node;
+  }
+  addRootRel8ns() {
+    let t = this;
+    t.addRootRel8n_Identity();
   }
   /**
    * Adds "important" rel8ns that are not collapsed by default.
@@ -1042,14 +1048,14 @@ export class DynamicIbScape extends DynamicD3ForceGraph {
   removeChildren(node, durationMs) {
     let t = this;
 
-    if (durationMs) {
+    let transition =
+      d3.transition()
+        .duration(durationMs)
+        .ease(d3.easeLinear);
 
-      let transition =
-        d3.transition()
-          .duration(durationMs)
-          .ease(d3.easeLinear);
-
-      t.getChildren(node).forEach(child => {
+    t.getChildren(node).forEach(child => {
+      if (durationMs) {
+      
         let radius = t.getNodeShapeRadius(child);
         let cx = node.x - child.x - radius;
         let cy = node.y - child.y - radius;
@@ -1075,17 +1081,19 @@ export class DynamicIbScape extends DynamicD3ForceGraph {
           // d3.select("#" + t.getNodeImageGroupId(child)),
 
         setTimeout(() => t.removeNodeAndChildren(child), durationMs);
-      });
-    } else {
-      t.removeNodeAndChildren(child)
-    }
-
+      } else {
+        t.removeNodeAndChildren(child)
+      }
+    });
   }
   removeNodeAndChildren(node) {
     let t = this;
     let children = t.getChildren(node);
     children.forEach(child => t.removeNodeAndChildren(child));
     t.remove(node, /*updateParentOrChild*/ true);
+    if (t.virtualNodes[node.id]) {
+      delete t.virtualNodes[node.id];
+    }
   }
 
   add(nodesToAdd, linksToAdd, updateParentOrChild) { 
@@ -1099,7 +1107,7 @@ export class DynamicIbScape extends DynamicD3ForceGraph {
     
     // console.log(`${lc} start. dToRemove.id & ibGib: ${dToRemove.id} ${dToRemove.ibGib}`);
 
-    if (!t.expanding && !t.fullyExpanding) {
+    if (dToRemove.type === "ibGib" && !t.expanding && !t.fullyExpanding) {
       t.ibGibEventBus.disconnect(dToRemove.id);
     }
 
@@ -1114,7 +1122,7 @@ export class DynamicIbScape extends DynamicD3ForceGraph {
       t.rootPulseTimer = setTimeout(() => {
         // if still no nodes
         if (t.graphData.nodes.length === 0) {
-          t.addRootNode();
+          t.showRootNode();
         }
       }, t.config.other.rootPulseMs);
     }
@@ -1127,17 +1135,7 @@ export class DynamicIbScape extends DynamicD3ForceGraph {
   /** Adds the root */
   addRootNode() {
     let t = this;
-    // console.log("addRootNode");
-
-    // Remove existing rootNode (if exists)
-    if (t.rootNode) {
-      t.rootPos.x = t.rootNode.x;
-      t.rootPos.y = t.rootNode.y;
-
-      t.clearFadeTimeout(t.rootNode);
-      t.remove(t.rootNode);
-    }
-
+    
     // Setup the rootNode params based on environment.
     let nonRootNodeCount = t.graphData.nodes.length;
     let rootId = t.getUniqueId("root"),
@@ -1158,16 +1156,87 @@ export class DynamicIbScape extends DynamicD3ForceGraph {
       fadeTimeoutMs = t.config.other.rootFadeTimeoutMs;
     }
 
-    // Add the rootNode
-    t.rootNode = t.addVirtualNode(rootId, rootType, rootIbGib, /*srcNode*/ null, rootShape, autoZap, /*fadeTimeoutMs*/ 0, /*cmd*/ null, /*title*/ null, /*label*/ null, /*startPos*/ null, /*isAdjunct*/ false);
-
-    if (!t.contextIbGib || t.contextIbGib === "ib^gib") {
-      t.rootNode.isSource = true;
+    if (t.rootNode) {
+      // Root node is already created. Just re-add to the graph.
+      t.add([t.rootNode], [], /*updateParentOrChild*/ true);
+    } else {
+      // Root node has not yet been created. Create it and then add.
+      t.rootNode = t.addVirtualNode(
+        rootId, 
+        rootType, 
+        rootIbGib, 
+        /*srcNode*/ null, 
+        rootShape, 
+        autoZap, 
+        /*fadeTimeoutMs*/ 0, 
+        /*cmd*/ null, 
+        /*title*/ null, 
+        /*label*/ null, 
+        /*startPos*/ null, 
+        /*isAdjunct*/ false
+      );
+      
+      if (!t.contextIbGib || t.contextIbGib === "ib^gib") {
+        t.rootNode.isSource = true;
+      }
+      t.rootNode.isRoot = true;
+      t.rootNode.isMeta = true;
+      // Restore the rootNode's position if we were replacing an existing one.
+      t.rootNode.x = t.rootPos.x;
+      t.rootNode.y = t.rootPos.y;
     }
-    t.rootNode.isRoot = true;
-    // Restore the rootNode's position if we were replacing an existing one.
-    t.rootNode.x = t.rootPos.x;
-    t.rootNode.y = t.rootPos.y;
+  }
+  showRootNode() {
+    let t = this;
+    // console.log("showRootNode");
+
+    // Remove existing rootNode (if exists)
+    if (t.rootNode && t.rootNode.inGraph) {
+      t.rootPos.x = t.rootNode.x;
+      t.rootPos.y = t.rootNode.y;
+
+      t.clearFadeTimeout(t.rootNode);
+      t.remove(t.rootNode);
+      t.rootNode.inGraph = false;
+    }
+
+    t.addRootNode();
+  }
+  addRootRel8n_Identity() {
+    let t = this;
+
+    if (t.rootRel8nNode_Identity) {
+      t.clearFadeTimeout(t.rootRel8nNode_Identity);
+      t.removeNodeAndChildren(t.rootRel8nNode_Identity);
+      delete t.rootRel8nNode_Identity; 
+    }
+    
+    t.rootRel8nNode_Identity = t.addRel8nVirtualNode(t.rootNode, "current identity", /*fadeTimeoutMs*/ t.config.other.cmdFadeTimeoutMs_Default);
+    t.rootRel8nNode_Identity.isMeta = true;
+  }
+  expandRootRel8n_Identity() {
+    let t = this;
+    let rel8nNode = t.rootRel8nNode_Identity;
+    t.clearFadeTimeout(rel8nNode);
+    
+    t.currentIdentityIbGibs.forEach(identityIbGib => {
+      if (identityIbGib === "ib^gib") { return; }
+      let identityNode = t.addVirtualNode(/*id*/ null, /*type*/ "ibGib", /*nameOrIbGib*/ identityIbGib, /*srcNode*/ rel8nNode, /*shape*/ "circle", /*autoZap*/ true, /*fadeTimeoutMs*/ 0, /*cmd*/ null, /*title*/ "...", /*label*/ "", /*startPos*/ {x: rel8nNode.x, y: rel8nNode.y}, /*isAdjunct*/ false);
+      identityNode.isMeta = true;
+      identityNode.isPaused = true;
+      identityNode.parentNode = rel8nNode;
+    });
+  }
+  removeRootNode() {
+    let t = this;
+    t.graphData.nodes
+      .filter(n => n.isMeta)
+      .forEach(n => t.fadeOutNode(n, t.config.other.rootFadeTimeoutMs_Fast));
+      
+    if (t.rootRel8nNode_Identity) { 
+      t.clearFadeTimeout(t.rootRel8nNode_Identity);
+      delete t.rootRel8nNode_Identity; 
+    }
   }
   addContextNode() {
     let t = this;
@@ -1456,8 +1525,13 @@ export class DynamicIbScape extends DynamicD3ForceGraph {
     t.removeVirtualNode(node);
     delete node.virtualId;
     t.add([node], [{source: node.rel8nSrc.id, target: node.id}], /*updateParentOrChild*/ true);
-    if (node.parentNode.isGreen && !node.isPaused) {
-      node.isGreen = true;
+    if (node.isMeta) {
+      t.showRootNode();
+      t.clearFadeTimeout(t.rootNode);
+    } else {
+      if (node.parentNode.isGreen && !node.isPaused) {
+        node.isGreen = true;
+      }
     }
     t.expandNode(node, callback);
   }
@@ -1507,12 +1581,13 @@ export class DynamicIbScape extends DynamicD3ForceGraph {
   _expandNode_Root(node, callback) {
     let t = this;
     t.addCmdVirtualNodes_Default(node);
+    t.addRootRel8ns();
     if (callback) { callback(); }
   }
   _expandNode_IbGib(node, callback) {
     let t = this;
 
-    if (node.expanding) {
+    if (node.expanding || node.isMeta) {
       if (callback) { callback(); }
       return;
     } else {
@@ -1534,7 +1609,6 @@ export class DynamicIbScape extends DynamicD3ForceGraph {
 
     // Do this whenever done (after zapping children if required).
     let finalize = () => {
-      // t.addCmdVirtualNodes_Default(node);
       delete node.expanding;
       if (callback) { callback(); }
     };
@@ -1604,33 +1678,47 @@ export class DynamicIbScape extends DynamicD3ForceGraph {
     } else {
       // Add the children ibGibs listed in the src rel8ns.
       let { rel8nName, rel8nSrc } = rel8nNode;
-      let rel8dIbGibs = rel8nSrc.ibGibJson.rel8ns[rel8nName] || [];
-      let rel8dIbGibNodes = [];
-      rel8dIbGibs
-        .forEach(rel8dIbGib => {
-          let rel8dIbGibNode = t.addVirtualNode(/*id*/ null, /*type*/ "ibGib", /*nameOrIbGib*/ t.ibGibProvider.getLatestIbGib(rel8dIbGib), /*srcNode*/ rel8nNode, /*shape*/ "circle", /*autoZap*/ true, /*fadeTimeoutMs*/ 0, /*cmd*/ null, /*title*/ "...", /*label*/ "", /*startPos*/ {x: rel8nNode.x, y: rel8nNode.y}, /*isAdjunct*/ false);
-          rel8dIbGibNodes.push(rel8dIbGibNode);
-          rel8dIbGibNode.parentNode = rel8nNode;
-        });
-
-      if (d3PausedRel8ns.includes(rel8nNode.rel8nName)) {
-        // Mark all children as paused.
-        rel8dIbGibNodes.forEach(n => {
-          n.isPaused = true;
-        });
+      if (rel8nSrc.isMeta) {
+        t._expandNode_MetaRel8n(rel8nNode, callback);
       } else {
-        // Refresh children ibGibs.
-        let ibGibsToRefresh = rel8dIbGibs.concat([rel8nSrc.ibGib]);
-        t.backgroundRefresher.enqueue(ibGibsToRefresh);
+        let rel8dIbGibs = rel8nSrc.ibGibJson.rel8ns[rel8nName] || [];
+        let rel8dIbGibNodes = [];
+        rel8dIbGibs
+          .forEach(rel8dIbGib => {
+            let rel8dIbGibNode = t.addVirtualNode(/*id*/ null, /*type*/ "ibGib", /*nameOrIbGib*/ t.ibGibProvider.getLatestIbGib(rel8dIbGib), /*srcNode*/ rel8nNode, /*shape*/ "circle", /*autoZap*/ true, /*fadeTimeoutMs*/ 0, /*cmd*/ null, /*title*/ "...", /*label*/ "", /*startPos*/ {x: rel8nNode.x, y: rel8nNode.y}, /*isAdjunct*/ false);
+            rel8dIbGibNodes.push(rel8dIbGibNode);
+            rel8dIbGibNode.parentNode = rel8nNode;
+          });
 
-        // Sync adjuncts, passing callback.
-        t.syncAdjuncts(rel8nNode.rel8nSrc.tempJuncIbGib, () => {
-          if (callback) { callback(); }
-        });
+        if (d3PausedRel8ns.includes(rel8nNode.rel8nName)) {
+          // Mark all children as paused.
+          rel8dIbGibNodes.forEach(n => {
+            n.isPaused = true;
+          });
+        } else {
+          // Refresh children ibGibs.
+          let ibGibsToRefresh = rel8dIbGibs.concat([rel8nSrc.ibGib]);
+          t.backgroundRefresher.enqueue(ibGibsToRefresh);
+
+          // Sync adjuncts, passing callback.
+          t.syncAdjuncts(rel8nNode.rel8nSrc.tempJuncIbGib, () => {
+            if (callback) { callback(); }
+          });
+        }
       }
     }
 
     rel8nNode.expandLevel = 1;
+  }
+  _expandNode_MetaRel8n(rel8nNode, callback) {
+    let t = this;
+    if (rel8nNode === t.rootRel8nNode_Identity) {
+      t.expandRootRel8n_Identity();
+    } else {
+      console.error(`Unknown meta rel8n node`);
+    }
+    
+    if (callback) { callback(); }
   }
   _refreshIbGibsForAutoExpansion(node, autoExpandRel8ns, callback) {
     let t = this;
@@ -2203,8 +2291,11 @@ export class DynamicIbScape extends DynamicD3ForceGraph {
     let t = this;
 
     if (t.rootNode) { t.clearFadeTimeout(t.rootNode); }
+    t.removeRootNode();
+    
+    // t.removeChildren(t.rootNode, /*durationMs*/ 0); // immediately
 
-    t.addRootNode();
+    t.showRootNode();
 
     let transform = ibHelper.parseTransformString(t.svgGroup.attr("transform"));
 
@@ -2321,7 +2412,9 @@ export class DynamicIbScape extends DynamicD3ForceGraph {
     // t.freezeNode(d, 1000);
     t.clearSelectedNode();
     t.animateNodeBorder(d, /*nodeShape*/ null);
-    if (!d.isRoot) { t.fadeOutNode(t.rootNode, t.config.other.rootFadeTimeoutMs_Fast); }
+    if (!d.isMeta) { 
+      t.removeRootNode();
+    }
 
     if (d.expanding) { delete d.expanding; }
     t.zap(d, () => {
@@ -2331,9 +2424,11 @@ export class DynamicIbScape extends DynamicD3ForceGraph {
   handleNodeDblClicked(d) {
     let t = this;
 
-    if (d.isRoot) {
+    if (d.isMeta) {
       return;
     }
+
+    t.removeRootNode();
 
     let isCancelledFunc = () => {
       return !d.fullyExpanding;
@@ -2573,4 +2668,6 @@ export class DynamicIbScape extends DynamicD3ForceGraph {
     // Thanks SO! http://stackoverflow.com/a/28171425/4275029
     setTimeout(() => window.location.reload());
   }
+  
+  
 }

--- a/ib_gib_umb/apps/web_gib/web/static/js/huh-texts/commands/ident-email.js
+++ b/ib_gib_umb/apps/web_gib/web/static/js/huh-texts/commands/ident-email.js
@@ -3,6 +3,11 @@ function getSpan() {
   return `<span style="padding: 5px; width: 70px; font-family: FontAwesome; background-color: #FFFFFF; border-radius: 15px">${iTag}</span>`;
 }
 
+function getSpan_UnIdent() {
+  let iTag = `<i class="fa fa-sign-out" aria-hidden="true"></i>`;
+  return `<span style="padding: 5px; width: 70px; font-family: FontAwesome; background-color: #7D7D7D; border-radius: 15px">${iTag}</span>`;
+}
+
 function getSpan_Root() {
   let iTag = `<i class="fa fa-circle-o" aria-hidden="true"></i>`;
   return `<span style="padding: 5px; width: 70px; font-family: FontAwesome; background-color: #76963e; border-radius: 15px">${iTag}</span>`;
@@ -12,10 +17,12 @@ var huhText_Cmd_IdentEmail = `
 
 ## Identify ${getSpan()}
 
-This command will identify you in ibGib with an email address. 
+The Identify command will identify you in ibGib with an email address. 
 
 **_This email address will be publicly visible. Please do not use ibGib if you
 wish your email address to remain private. Thank You!_** :smiley:
+
+You can also sign out by choosing the Unidentify command (${getSpan_UnIdent()}).
 
 ### :baby: :baby_bottle:
 

--- a/ib_gib_umb/apps/web_gib/web/static/js/services/commanding/command-manager.js
+++ b/ib_gib_umb/apps/web_gib/web/static/js/services/commanding/command-manager.js
@@ -2,7 +2,6 @@ import * as d3 from 'd3';
 
 import * as commands from './commands';
 import { CommandBus } from './command-bus';
-// import * as ibHelper from '../services/ibgib-helper';
 
 export class CommandManager {
   constructor(ibScape, ibGibSocketManager) {
@@ -48,9 +47,6 @@ export class CommandManager {
       case "query":
         t.ibScape.currentCmd = t.getCommand_Query(dIbGib);
         break;
-      // case "help":
-      //   t.ibScape.currentCmd = t.getCommand_Help(dIbGib);
-      //   break;
       case "huh":
         t.ibScape.currentCmd = t.getCommand_Huh(dIbGib);
         break;
@@ -68,6 +64,9 @@ export class CommandManager {
         break;
       case "identemail":
         t.ibScape.currentCmd = t.getCommand_IdentEmail(dIbGib);
+        break;
+      case "unidentemail":
+        t.ibScape.currentCmd = t.getCommand_UnIdentEmail(dIbGib);
         break;
       case "pic":
         t.ibScape.currentCmd = t.getCommand_Pic(dIbGib);
@@ -97,37 +96,12 @@ export class CommandManager {
         console.error(`unknown cmdName: ${cmdName}`);
     }
 
-    //
-    // if ((cmdName === "view" || cmdName === "hide")) {
-    //   t.execView(dIbGib)
-    // } else if (cmdName === "goto") {
-    //   t.execGoto(dIbGib);
-    // } else if (cmdName === "pic") {
-    //   t.execPic(dIbGib);
-    // } else if (cmdName === "fullscreen") {
-    //   t.execFullscreen(dIbGib);
-    // } else if (cmdName === "link") {
-    //   t.execLink(dIbGib);
-    // } else if (cmdName === "externallink") {
-    //   t.execExternalLink(dIbGib);
-    // } else if (cmdName === "identemail") {
-    //   t.execIdentEmail(dIbGib);
-    // } else if (cmdName === "info") {
-    //   t.ibScape.currentCmd = t.getCommand_Info(dIbGib);
-    // } else if (cmdName === "query") {
-    //   t.ibScape.currentCmd = t.getCommand_Query(dIbGib);
-    //   // t.execQuery(dIbGib);
-    // } else if (cmdName === "refresh") {
-    //   t.execRefresh(dIbGib);
-    // } else if (cmdName === "download") {
-    //   t.execDownload(dIbGib);
-    // }
-
     if (t.ibScape.currentCmd) {
       t.ibScape.currentCmd.exec();
       t.ibScape.clearSelectedNode();
     }
   }
+
   getCommand_rel8nAdd(dIbGib) {
     let t = this;
     switch (dIbGib.rel8nName) {
@@ -147,70 +121,13 @@ export class CommandManager {
         throw new Error(`Unknown rel8n to add: ${dIbGib.rel8nName}`);
     }
   }
-  // execView(dIbGib) {
-  //   this.ibScape.toggleExpandNode(dIbGib);
-  //   this.ibScape.destroyStuff();
-  //   this.ibScape.update(null);
-  // }
-  // execFork(dIbGib) {
-  //   let init = () => {
-  //     d3.select("#fork_form_data_src_ib_gib")
-  //       .attr("value", dIbGib.ibgib);
-  //   };
-  //   this.ibScape.showDetails("fork", init);
-  //   $("#fork_form_data_dest_ib").focus();
-  // }
+
   getCommand_Goto(dIbGib) {
     return new commands.GotoCommand(this.ibScape, dIbGib);
   }
   getCommand_Info(dIbGib) {
     return new commands.InfoDetailsCommand(this.ibScape, dIbGib);
   }
-  // execPic(dIbGib) {
-  //   let init = () => {
-  //     d3.select("#pic_form_data_src_ib_gib")
-  //       .attr("value", dIbGib.ibgib);
-  //   };
-  //   this.ibScape.showDetails("pic", init);
-  //   $("#pic_form_data_file").focus();
-  // }
-  // execLink(dIbGib) {
-  //   let init = () => {
-  //     d3.select("#link_form_data_src_ib_gib")
-  //       .attr("value", dIbGib.ibgib);
-  //   };
-  //   this.ibScape.showDetails("link", init);
-  //   $("#link_form_data_text").focus();
-  // }
-  // execFullscreen(dIbGib) {
-  //   if (dIbGib.ibgib === "ib^gib") {
-  //     let id = this.ibScape.graphDiv.id;
-  //     this.ibScape.toggleFullScreen(`#${id}`);
-  //   } else {
-  //     this.ibScape.openImage(dIbGib.ibgib);
-  //   }
-  // }
-  // execExternalLink(dIbGib) {
-  //   let ibGibJson = this.ibGibCache.get(dIbGib.ibgib);
-  //   let url = ibHelper.getDataText(ibGibJson);
-  //   if (url) {
-  //     window.open(url,'_blank');
-  //   } else {
-  //     alert("Error opening external link... :-/");
-  //   }
-  // }
-  // execIdentEmail(dIbGib) {
-  //   let init = () => {
-  //     d3.select("#ident_form_data_src_ib_gib")
-  //       .attr("value", dIbGib.ibgib);
-  //   };
-  //   this.ibScape.showDetails("ident", init);
-  //   $("#ident_form_data_text").focus();
-  // }
-
-  // getCommand_Help(dIbGib) {
-  //   return new commands.HelpDetailsCommand(this.ibScape, dIbGib);
-  // }
   getCommand_Huh(dIbGib) {
     return new commands.HuhDetailsCommand(this.ibScape, dIbGib);
   }
@@ -231,6 +148,9 @@ export class CommandManager {
   }
   getCommand_IdentEmail(dIbGib) {
     return new commands.IdentEmailDetailsCommand(this.ibScape, dIbGib);
+  }
+  getCommand_UnIdentEmail(dIbGib) {
+    return new commands.UnIdentEmailDetailsCommand(this.ibScape, dIbGib);
   }
   getCommand_Pic(dIbGib) {
     return new commands.PicDetailsCommand(this.ibScape, dIbGib);
@@ -253,57 +173,4 @@ export class CommandManager {
   getCommand_Zap(dIbGib) {
     return new commands.ZapCommand(this.ibScape, dIbGib);
   }
-
-  // execRefresh(dIbGib) {
-  //   location.href = `/ibgib/${dIbGib.ibgib}?latest=true`
-  // }
-  // execDownload(dIbGib) {
-  //   let t = this;
-  //   let imageUrl =
-  //     t.ibScape.ibGibImageProvider.getFullImageUrl(dIbGib.ibgib);
-  //
-  //   let init = () => {
-  //     let btn = d3.select("#download_form_submit_btn");
-  //     btn
-  //       .attr("href", imageUrl)
-  //       .attr("download", "");
-  //
-  //     if (!btn.node().onclick) {
-  //       btn.node().onclick = () => {
-  //         t.ibScape.cancelDetails();
-  //         t.ibScape.clearSelectedNode();
-  //       }
-  //     }
-  //
-  //     d3.select("#download_form_url")
-  //       .text(imageUrl);
-  //
-  //     d3.select("#download_form_filetype")
-  //       .text("not set");
-  //
-  //     d3.select("#download_form_filename")
-  //       .text("not set");
-  //
-  //     t.ibScape.repositionDetails();
-  //
-  //     t.ibScape.getIbGibJson(dIbGib.ibgib, (ibGibJson) => {
-  //       if (ibGibJson.data) {
-  //         if (ibGibJson.data.content_type) {
-  //           d3.select("#download_form_filetype")
-  //             .text(ibGibJson.data.content_type);
-  //         }
-  //         if (ibGibJson.data.filename) {
-  //           d3.select("#download_form_filename")
-  //             .text(ibGibJson.data.filename);
-  //           btn
-  //             .attr("download", ibGibJson.data.filename);
-  //         }
-  //       }
-  //     });
-  //   };
-  //
-  //   t.ibScape.showDetails("download", init);
-  //
-  //   $("#download_form_submit_btn").focus();
-  // }
 }

--- a/ib_gib_umb/apps/web_gib/web/static/js/services/commanding/commands.js
+++ b/ib_gib_umb/apps/web_gib/web/static/js/services/commanding/commands.js
@@ -858,23 +858,6 @@ export class IdentEmailDetailsCommand extends FormDetailsCommandBase {
     $("#identemail_form_data_text").focus();
   }
 
-  getMessageData() {
-    // MessageData is not used in ident email. Uses xhr.
-
-    // let t = this;
-    //
-    // document.getElementById('pic_form_data_file').files[0]
-    //
-    // var formData = new FormData();
-    // formData.append("fileToUpload", document.getElementById('fileToUpload').files[0]);
-    //
-    // return {
-    //   virtual_id: t.virtualNode.virtualId,
-    //   src_ib_gib: t.d.type === "rel8n" ? t.d.rel8nSrc.ibGib : t.d.ibGib,
-    //   comment_text: $("#comment_form_data_text").val()
-    // };
-  }
-
   /**
    * Default implementation is for a command that will produce a single virtual
    * node that will be busy while the message is sent to the server via the
@@ -899,28 +882,6 @@ export class IdentEmailDetailsCommand extends FormDetailsCommandBase {
     xhr.open("POST", "/ibgib/ident");
     xhr.send(formData);
 
-    // if (form.checkValidity()) {
-    //   console.log("form is valid");
-    //   t.addVirtualNode();
-    //   t.ibScape.setBusy(t.virtualNode);
-    //
-    //   let msg = t.getMessage();
-    //   t.ibScape.commandMgr.bus.send(msg, (successMsg) => {
-    //     t.ibScape.clearBusy(t.virtualNode);
-    //     if (t.handleSubmitResponse) {
-    //       t.handleSubmitResponse(successMsg);
-    //     }
-    //   }, (errorMsg) => {
-    //     console.error(`Command errored. Msg: ${JSON.stringify(errorMsg)}`);
-    //     t.ibScape.clearBusy(t.virtualNode);
-    //     t.virtualNode.type = "error";
-    //     t.virtualNode.errorMsg = JSON.stringify(errorMsg);
-    //     t.ibScape.zap(t.virtualNode, /*callback*/ null);
-    //   });
-    // } else {
-    //   console.log("form is invalid");
-    // }
-
     t.close();
   }
 
@@ -936,32 +897,71 @@ export class IdentEmailDetailsCommand extends FormDetailsCommandBase {
   xhrCanceled(evt) {
     console.log(`xhrCanceled. The upload has been canceled by the user or the browser dropped the connection.`);
   }
+}
 
-  // handleSubmitResponse(msg) {
-  //   let t = this;
-  //
-  //   if (msg && msg.data && msg.data.comment_ib_gib) {
-  //     if (msg.data.new_src_ib_gib) {
-  //       // The src was directly commented on, so this user had authz to
-  //       // do it (it's the ibGib's owner). So set the comment ibGib and
-  //       // zap it.
-  //       let commentIbGib = msg.data.comment_ib_gib;
-  //       t.virtualNode.ibGib = commentIbGib;
-  //       t.ibScape.zap(t.virtualNode, /*callback*/ null);
-  //     } else {
-  //       // The src was not updated, so this is a user commenting on
-  //       // someone else's ibGib. So a comment was created and was rel8d
-  //       // to the src, but the src has not been inversely rel8d to the
-  //       // comment. So we'll remove the placeholder node and the
-  //       // :new_adjunct event will create a new node.
-  //
-  //       t.ibScape.remove(t.virtualNode);
-  //     }
-  //   } else {
-  //     console.error(`${typeof(t)}: Unknown msg response from channel.`);
-  //   }
-  // }
+export class UnIdentEmailDetailsCommand extends FormDetailsCommandBase {
+  constructor(ibScape, d) {
+    const cmdName = "unidentemail";
+    super(cmdName, ibScape, d);
+  }
 
+  init() {
+    let t = this;
+
+    d3.select("#unidentemail_form_data_src_ib_gib")
+      .attr("value", t.d.ibGib);
+
+    d3.select("#unidentemail_form_data_email_addr")
+      .text(t.d.ibGibJson.data.email_addr);
+
+    $("#ib-unidentemail-details-submit-btn").focus();
+  }
+
+  submitFunc() {
+    let t = this;
+    console.log(`${t.cmdName} cmd submitFunc`);
+    
+    let form = document.querySelector("#" + t.getFormId());
+    let formData = new FormData(form);
+
+    for (let [key, value] of formData.entries()) {
+      console.log(key, value);
+    }
+
+    let xhr = new XMLHttpRequest();
+    xhr.addEventListener("load", (evt) => t.xhrComplete(evt, t.d.ibGibJson.data.email_addr), false);
+    xhr.addEventListener("error", t.xhrFailed, false);
+    xhr.addEventListener("abort", t.xhrCanceled, false);
+    xhr.open("POST", "/ibgib/unident");
+    xhr.send(formData);
+
+    t.close();
+  }
+
+  /* 
+   * This event is raised when the server send back a response (even if it's an
+   * error response 500, 400, etc.)
+   */
+  xhrComplete(evt, emailAddress) {
+    let t = this;
+    console.log(`xhrComplete. response status: ${evt.target.status}`)
+    if (evt.target.status === 200) {
+      alert(`${emailAddress} has been removed from your current identity. The page must now reload.`);
+      
+      // Thanks SO! http://stackoverflow.com/a/28171425/4275029
+      setTimeout(() => window.location.reload());
+    } else {
+      alert(`Logging out ${emailAddress} had an error: ${evt.target.responseText}}`);
+    }
+  }
+
+  xhrFailed(evt) {
+    console.log(`xhrFailed. evt: ${JSON.stringify(evt)}`);
+  }
+
+  xhrCanceled(evt) {
+    console.log(`xhrCanceled. evt: ${JSON.stringify(evt)}`);
+  }
 }
 
 export class PicDetailsCommand extends FormDetailsCommandBase {

--- a/ib_gib_umb/apps/web_gib/web/static/js/services/commanding/commands.js
+++ b/ib_gib_umb/apps/web_gib/web/static/js/services/commanding/commands.js
@@ -948,8 +948,10 @@ export class UnIdentEmailDetailsCommand extends FormDetailsCommandBase {
     if (evt.target.status === 200) {
       alert(`${emailAddress} has been removed from your current identity. The page must now reload.`);
       
-      // Thanks SO! http://stackoverflow.com/a/28171425/4275029
-      setTimeout(() => window.location.reload());
+      // Do we even get here?
+      
+      // // Thanks SO! http://stackoverflow.com/a/28171425/4275029
+      // setTimeout(() => window.location.reload());
     } else {
       alert(`Logging out ${emailAddress} had an error: ${evt.target.responseText}}`);
     }

--- a/ib_gib_umb/apps/web_gib/web/static/js/services/ibgib-authz.js
+++ b/ib_gib_umb/apps/web_gib/web/static/js/services/ibgib-authz.js
@@ -137,3 +137,13 @@ function _getIdentityType(identityIbGib) {
     return identityType;
   }
 }
+
+export function isEmailIdentity(ibGibJson) {
+  let { ib, gib, rel8ns, data } = ibGibJson;
+  return ib.startsWith("email_") &&
+         gib.startsWith("ibGib_") && 
+         rel8ns.instance_of &&
+         rel8ns.instance_of.length === 1 && 
+         rel8ns.instance_of[0] === "identity^gib" &&
+         data.type === "email";
+}

--- a/ib_gib_umb/apps/web_gib/web/static/js/services/ibgib-event-bus.js
+++ b/ib_gib_umb/apps/web_gib/web/static/js/services/ibgib-event-bus.js
@@ -79,6 +79,7 @@ export class IbGibEventBus {
     channel.on("adjuncts", msg => t.handleMsg(ibGib, msg));
     channel.on("new_adjunct", msg => t.handleMsg(ibGib, msg));
     channel.on("ident_email", msg => t.handleMsg(ibGib, msg));
+    channel.on("unident_email", msg => t.handleMsg(ibGib, msg));
 
     return channel;
   }


### PR DESCRIPTION
I've added identity rel8n node on the root ibGib so that you can easily check which identities are currently logged in there. I also :wrench: implemented unidentify (log out) via a similar mechanism to the login in that it uses xhr and goes through the controller instead of the command bus.

This UX still isn't super awesome, in that it requires you to visually check to see which ones are logged in. 

It would be better to have a UX that pops up and is more visible, because it would be a decent attack to log someone out (no password is required) and then they would be acting on lowered credentials. This is not a huge deal though, since it would be immediately obvious if they are acting on existing ibGib, i.e. this is only susceptible if they immediately create a "blank" ibGib from scratch.