### PR TITLE
Confirm cancel on comment/mut8

### DIFF
--- a/ib_gib_umb/apps/web_gib/web/static/js/graphs/dynamic-ib-scape-menu.js
+++ b/ib_gib_umb/apps/web_gib/web/static/js/graphs/dynamic-ib-scape-menu.js
@@ -232,6 +232,7 @@ export class DynamicIbScapeMenu extends DynamicD3ForceGraph {
         cmdNames.push("view");
 
         if (ibAuthz.isAuthorizedForMut8OrRel8(d.ibGibJson, t.ibScape.currentIdentityIbGibs)) {
+          // debugger;
           cmdNames.push("mut8comment");
         }
       }

--- a/ib_gib_umb/apps/web_gib/web/static/js/services/commanding/commands.js
+++ b/ib_gib_umb/apps/web_gib/web/static/js/services/commanding/commands.js
@@ -223,6 +223,7 @@ export class FormDetailsCommandBase extends DetailsCommandBase {
     let form = document.getElementById(t.getFormId());
     if (form.checkValidity()) {
       console.log("form is valid");
+      t.submitted = true;
       t.addVirtualNode(() => {
         t.ibScape.setBusy(t.virtualNode);
 
@@ -604,6 +605,18 @@ export class CommentDetailsCommand extends FormDetailsCommandBase {
     $("#comment_form_data_text").val("").focus();
   }
 
+  close() {
+    let t = this;
+    
+    let commentText = $("#comment_form_data_text").val();
+    if (!t.submitted && commentText) {
+      let confirmMsg = `Lose unsaved changes?\n\nPress OK to close and lose unsaved changes.\nPress Cancel to return to editing your text.`;
+      if (!confirm(confirmMsg)) { return; }
+    }
+
+    super.close();
+  }
+  
   /** Currently just trims whitespace of comment. */
   sanitizeFormFields() {
     let commentText = $("#comment_form_data_text").val();
@@ -697,6 +710,16 @@ export class Mut8CommentDetailsCommand extends FormDetailsCommandBase {
 
   close() {
     let t = this;
+
+    if (!t.submitted) {
+      let commentText = $("#comment_form_data_text").val();
+      
+      if (commentText !== t.initialCommentText) {
+        let confirmMsg = `Lose unsaved changes?\n\nPress OK to close and lose unsaved changes.\nPress Cancel to return to editing your text.`;
+        if (!confirm(confirmMsg)) { return; }
+      }
+    } 
+    
     if (!t.submitted && t.srcNode) {
       t.ibScape.clearBusy(t.srcNode);
     }

--- a/ib_gib_umb/apps/web_gib/web/static/js/services/ibgib-authz.js
+++ b/ib_gib_umb/apps/web_gib/web/static/js/services/ibgib-authz.js
@@ -59,7 +59,8 @@ function _isAuthorizedForMut8OrRel8_Session(targetIdentityIbGibs, currentIdentit
   // authorized.
   let authorized =
     targetIdentityIbGibs
-      .filter(targetIdentityIbGib => targetIdentityIbGib !== "ib^gib")
+      // .filter(targetIdentityIbGib => targetIdentityIbGib !== "ib^gib")
+      .filter(targetIdentityIbGib => getIdentityType(targetIdentityIbGib) === "session")
       .reduce((authorized, targetIdentityIbGib) => {
         if (authorized) {
           // bypass further checking since we know we're authorized


### PR DESCRIPTION
* :wrench: Confirmation shown when cancelling either an altered mut8 or a
  non-empty new comment.
* :high_heel::bug: The mut8 command was being shown on the client when it
  wasn't supposed to be. This stemmed from the client-side authz not taking
  the node identity into account.
  * The server wouldn't allow the mut8 anyway, this was more of an :art: thing.

issue: closes #157